### PR TITLE
feat: consent mode added to plugin

### DIFF
--- a/platzky_google_tag_manager/plugin.py
+++ b/platzky_google_tag_manager/plugin.py
@@ -1,7 +1,8 @@
 """Platzky Google Tag Manager plugin — injects GTM tracking code into pages."""
 
+import json
 import re
-from typing import Any
+from typing import Any, Literal, Optional
 
 from platzky.plugin.html_injector import HtmlInjectorPluginBase
 from platzky.plugin.plugin import ConfigPluginError
@@ -9,11 +10,23 @@ from pydantic import BaseModel, ValidationError, field_validator
 
 GTM_ID_PATTERN = re.compile(r"^(GTM|G|AW|DC)-[A-Z0-9]+$")
 
+ConsentType = Literal[
+    "ad_storage",
+    "analytics_storage",
+    "ad_user_data",
+    "ad_personalization",
+    "functionality_storage",
+    "personalization_storage",
+    "security_storage",
+]
+ConsentStatus = Literal["granted", "denied"]
+
 
 class _Config(BaseModel):
     """Internal config model for the Google Tag Manager plugin."""
 
     ID: str
+    CONSENT_DEFAULT: Optional[dict[ConsentType, ConsentStatus]] = None
 
     @field_validator("ID")
     @classmethod
@@ -39,11 +52,32 @@ class GoogleTagManagerPlugin(HtmlInjectorPluginBase):
         except ValidationError as e:
             raise ConfigPluginError(str(e)) from e
         self._gtm_id = validated.ID
+        self._consent_default = validated.CONSENT_DEFAULT
+
+    def _get_consent_default_html(self) -> str:
+        """Return the gtag consent-default script, or an empty string if unconfigured.
+
+        Must be emitted before the GTM script tag: Consent Mode reads this default
+        the moment the container loads, so any CMP only needs to call
+        ``gtag('consent', 'update', ...)`` later to change it.
+        """
+        if not self._consent_default:
+            return ""
+        consent_json = json.dumps(self._consent_default)
+        return (
+            "<!-- Consent Mode default -->\n"
+            "<script>\n"
+            "window.dataLayer = window.dataLayer || [];\n"
+            "function gtag(){dataLayer.push(arguments);}\n"
+            f"gtag('consent', 'default', {consent_json});\n"
+            "</script>\n"
+            "<!-- End Consent Mode default -->\n"
+        )
 
     def get_head_html(self) -> str:
-        """Return the GTM script tag for injection into ``<head>``."""
+        """Return the consent default (if configured) and GTM script tag for ``<head>``."""
         gtm_id = self._gtm_id
-        return (
+        gtm_script = (
             "<!-- Google Tag Manager -->\n"
             "<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':\n"
             "new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],\n"
@@ -52,6 +86,7 @@ class GoogleTagManagerPlugin(HtmlInjectorPluginBase):
             "})(window,document,'script','dataLayer','" + gtm_id + "');</script>\n"
             "<!-- End Google Tag Manager -->\n"
         )
+        return self._get_consent_default_html() + gtm_script
 
     def get_body_html(self) -> str:
         """Return the GTM noscript iframe for injection at the start of ``<body>``."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.14"
 platzky = "^2.0.0a4"
 
 [tool.poetry.plugins."platzky.plugins"]
-google-tag-manager = "platzky_google_tag_manager:GoogleTagManagerPlugin"
+google_tag_manager = "platzky_google_tag_manager:GoogleTagManagerPlugin"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/tests/test_google_tag_manager_plugin.py
+++ b/tests/test_google_tag_manager_plugin.py
@@ -63,3 +63,45 @@ def test_accepts_valid_gtm_id(valid_id: str):
 
     assert valid_id in plugin.get_head_html()
     assert valid_id in plugin.get_body_html()
+
+
+def test_get_head_html_without_consent_default_omits_consent_script():
+    """Test that no consent script is emitted when CONSENT_DEFAULT is unset."""
+    plugin = GoogleTagManagerPlugin({"ID": "GTM-XXXX"})
+
+    head = plugin.get_head_html()
+
+    assert "consent" not in head.lower()
+
+
+def test_get_head_html_with_consent_default_precedes_gtm_script():
+    """Test that the consent default script is emitted before the GTM script."""
+    plugin = GoogleTagManagerPlugin(
+        {
+            "ID": "GTM-XXXX",
+            "CONSENT_DEFAULT": {
+                "ad_storage": "denied",
+                "analytics_storage": "denied",
+            },
+        }
+    )
+
+    head = plugin.get_head_html()
+
+    assert "gtag('consent', 'default'," in head
+    assert '"ad_storage": "denied"' in head
+    assert '"analytics_storage": "denied"' in head
+    assert head.index("gtag('consent', 'default',") < head.index("Google Tag Manager -->")
+
+
+@pytest.mark.parametrize(
+    "invalid_consent_default",
+    [
+        {"ad_storage": "maybe"},
+        {"not_a_real_consent_type": "granted"},
+    ],
+)
+def test_rejects_invalid_consent_default(invalid_consent_default: dict[str, str]):
+    """Test that plugin raises validation error for malformed consent defaults."""
+    with pytest.raises(ConfigPluginError):
+        GoogleTagManagerPlugin({"ID": "GTM-XXXX", "CONSENT_DEFAULT": invalid_consent_default})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Consent Mode default settings.
  * Configured consent defaults are now included in the page header before the Google Tag Manager script.
  * Consent defaults are omitted when no settings are provided.

* **Bug Fixes**
  * Added validation to reject malformed consent default configurations.
  * Updated plugin registration to ensure reliable discovery by the host system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->